### PR TITLE
Make it work on a NONE chroot env too

### DIFF
--- a/website_git.inc.php
+++ b/website_git.inc.php
@@ -66,6 +66,8 @@ class website_git {
 		$username = escapeshellcmd($data['new']['system_user']);
 		$groupname = escapeshellcmd($data['new']['system_group']);
 
+		$docroot = "/" . trim($data['new']['document_root'], "/");
+
 		$gitBinary = $this->_exec("which git"); //"/usr/bin/git";
 
 		$gitHook = <<<EOS
@@ -75,7 +77,7 @@ do
 	if [[ \$refname =~ .*/master\$ ]];
 	then
 		echo "Master received.  Deploying master branch to production..."
-		git --work-tree=/web --git-dir=/website.git checkout -f
+		git --work-tree=$docroot/web --git-dir=$docroot/website.git checkout -f
 	else
 		echo "Ref \$refname successfully received.  Doing nothing: only the master branch may be deployed on this server."
 	fi
@@ -89,8 +91,6 @@ thumbs.db
 ._*
 *.DS_Store
 EOS;
-
-		$docroot = "/" . trim($data['new']['document_root'], "/");
 
 		$app->system->web_folder_protection($data['new']['document_root'],false);
 

--- a/website_git.inc.php
+++ b/website_git.inc.php
@@ -111,6 +111,12 @@ EOS;
 			//$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' config core.worktree "/web"');
 		}
 
+		if(!@is_dir($docroot.'/'.$docroot)){
+			$app->system->mkdirpath($docroot.'/'.$docroot, 0711, $username, $groupname);
+			$app->system->create_relative_link($docroot . '/web', $docroot . '/' . $docroot . '/web');
+			$app->system->create_relative_link($docroot . '/website.git', $docroot . '/' . $docroot . '/website.git');
+		}
+
 		$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' config user.name "' . escapeshellarg($username) . '"');
 		$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' config user.email "' . escapeshellarg($username . "@" . $groupname) . '"');
 


### PR DESCRIPTION
The absolute path /web and /website.git breaks the NONE `chroot` settings.

I'm not sure what the $docroot is in case of a `chroot` env but code is already using $docroot further down.