### PR TITLE
Fix folder permissions

### DIFF
--- a/website_git.inc.php
+++ b/website_git.inc.php
@@ -67,10 +67,11 @@ class website_git {
 		$groupname = escapeshellcmd($data['new']['system_group']);
 
 		$docroot = "/" . trim($data['new']['document_root'], "/");
+		$gitHookRoot = $docroot . '/githooks';
 
 		$gitBinary = $this->_exec("which git"); //"/usr/bin/git";
 
-		$gitHook = <<<EOS
+		$gitHookContent = <<<EOS
 #!/bin/bash
 while read oldrev newrev refname
 do
@@ -84,6 +85,9 @@ do
 done
 EOS;
 
+		$gitHookFile = $gitHookRoot . '/post-receive';
+		$gitHookSymLink = $docroot.'/website.git/hooks/post-receive';
+
 		$gitIgnore = <<<EOS
 stats/
 
@@ -93,6 +97,16 @@ thumbs.db
 EOS;
 
 		$app->system->web_folder_protection($data['new']['document_root'],false);
+		if ( !@is_dir($gitHookRoot) ) {
+			$app->system->mkdirpath($gitHookRoot, 0751, $username, $groupname);
+		}
+
+		if (!@is_file($gitHookFile)) {
+			$app->system->file_put_contents($gitHookFile, $gitHookContent);
+			$app->system->chmod($gitHookFile, 0755);
+			$app->system->chown($gitHookFile, $username);
+			$app->system->chgrp($gitHookFile, $groupname);
+		}
 
 		if(!@is_dir($docroot.'/website.git')){
 			$this->_exec($gitBinary . ' --bare init ' . escapeshellarg($docroot . "/website.git") . '');
@@ -120,10 +134,9 @@ EOS;
 		$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' config user.name "' . escapeshellarg($username) . '"');
 		$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' config user.email "' . escapeshellarg($username . "@" . $groupname) . '"');
 
-		$app->system->file_put_contents($docroot.'/website.git/hooks/post-receive', $gitHook);
-		$app->system->chmod($docroot.'/website.git/hooks/post-receive', 0755);
-		$app->system->chown($docroot.'/website.git/hooks/post-receive', $username);
-		$app->system->chgrp($docroot.'/website.git/hooks/post-receive', $groupname);
+		if ( !@is_link( $gitHookSymLink ) ) {
+			$app->system->create_relative_link($gitHookFile, $gitHookSymLink);
+		}
 
 		$this->_exec("chown " . escapeshellarg($username) . ":" . escapeshellarg($groupname) . " " . escapeshellarg($docroot . "/website.git") . " -R");
 

--- a/website_git.inc.php
+++ b/website_git.inc.php
@@ -112,7 +112,7 @@ EOS;
 		}
 
 		if(!@is_dir($docroot . $docroot)){
-			$app->system->mkdirpath($docroot . $docroot, 0711, 'root', 'root');
+			$app->system->mkdirpath($docroot . $docroot, 0755, 'root', 'root');
 			$app->system->create_relative_link($docroot . '/web', $docroot . $docroot . '/web');
 			$app->system->create_relative_link($docroot . '/website.git', $docroot . $docroot . '/website.git');
 		}

--- a/website_git.inc.php
+++ b/website_git.inc.php
@@ -106,8 +106,8 @@ EOS;
 			$app->system->chown($docroot.'/web/.gitignore', $username);
 			$app->system->chgrp($docroot.'/web/.gitignore', $groupname);
 
-			$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' add -A');
-			$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' commit -m "Initial commit"');
+			//$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' add -A');
+			//$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' commit -m "Initial commit"');
 			//$this->_exec($gitBinary . ' --work-tree=' . escapeshellarg($docroot . "/web") . ' --git-dir=' . escapeshellarg($docroot . "/website.git") . ' config core.worktree "/web"');
 		}
 

--- a/website_git.inc.php
+++ b/website_git.inc.php
@@ -112,7 +112,7 @@ EOS;
 		}
 
 		if(!@is_dir($docroot . $docroot)){
-			$app->system->mkdirpath($docroot . $docroot, 0711, $username, $groupname);
+			$app->system->mkdirpath($docroot . $docroot, 0711, 'root', 'root');
 			$app->system->create_relative_link($docroot . '/web', $docroot . $docroot . '/web');
 			$app->system->create_relative_link($docroot . '/website.git', $docroot . $docroot . '/website.git');
 		}


### PR DESCRIPTION
Hi,
To allow its use with shell user creation the "var" folder created to contain symlinks must be owned by root user. If not Jailkit will prevent copy of files and thus it will not work at all.

Regards